### PR TITLE
Add keyboard shortcut

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
   },
   "commands": {
     "_execute_browser_action": {
-      "suggested_key": { "default": "Ctrl+Shift+U" },
+      "suggested_key": { "default": "Ctrl+Alt+U" },
       "description": "Send a 'toggle-feature' event to the extension"
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
     "page": "js/background/index.html"
   },
   "commands": {
-    "toggle-feature": {
+    "_execute_browser_action": {
       "suggested_key": { "default": "Ctrl+Shift+U" },
       "description": "Send a 'toggle-feature' event to the extension"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": { "default": "Ctrl+Alt+U" },
-      "description": "Send a 'toggle-feature' event to the extension"
+      "description": "Open Profile Switcher Addon"
     }
   },
   "browser_specific_settings": {

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,12 @@
   "background": {
     "page": "js/background/index.html"
   },
+  "commands": {
+    "toggle-feature": {
+      "suggested_key": { "default": "Ctrl+Shift+U" },
+      "description": "Send a 'toggle-feature' event to the extension"
+    }
+  },
   "browser_specific_settings": {
     "gecko": {
       "id": "profile-switcher-ff@nd.ax"


### PR DESCRIPTION
This PR adds keyboard shortcut feature, allowing the  to be opened with keyboard.


here is the [psff-feat-keyboard-shortcut.zip](https://github.com/null-dev/firefox-profile-switcher/files/7766310/psff-feat-keyboard-shortcut.zip) for testing.