### PR TITLE
Set last focused Window as Default Profile

### DIFF
--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -75,6 +75,9 @@ async function initNativePort(eventCallback) {
             curProfileId = profileListData.current_profile_id;
         }
     }
+	
+	browser.windows.onFocusChanged.addListener(onWindowFocusChange);
+	
     nativeRequestInternal(nativePort, "Initialize", {
         extension_id: EXTENSION_ID,
         extension_version: APP_VERSION,
@@ -235,4 +238,21 @@ export async function nativeDeleteAvatar(id) {
 
 export async function nativeUpdateProfileOrder(order) {
     return await nativeRequest("UpdateProfileOrder", { order });
+}
+
+//Make the last focused window be the current "Default Profile" so that external links open in whatever was the last window you focused.
+export async function onWindowFocusChange(windowID) {
+	//We're not in the currently active Profile or no main window has been focused again yet
+	if(windowID < 0) { return; }
+
+	const profileList = await browser.storage.local.get(STORAGE_CACHE_PROFILE_LIST_KEY);
+    if(profileList != null) {
+        const profileListData = profileList[STORAGE_CACHE_PROFILE_LIST_KEY];
+        if(profileListData != null) {
+            let curProfile = profileListData.profiles.find((profile) => profile.id == profileListData.current_profile_id);
+			if(curProfile.default == true) { return; } //Don't waste time setting default again
+			
+			await nativeUpdateProfile(curProfile.id, curProfile.name, curProfile.avatar, true, curProfile.options);
+        }
+    }
 }

--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -249,7 +249,7 @@ export async function onWindowFocusChange(windowID) {
     if(profileList != null) {
         const profileListData = profileList[STORAGE_CACHE_PROFILE_LIST_KEY];
         if(profileListData != null) {
-            let curProfile = profileListData.profiles.find((profile) => profile.id == profileListData.current_profile_id);
+            const curProfile = profileListData.profiles.find((profile) => profile.id == profileListData.current_profile_id);
 			if(curProfile.default == true) { return; } //Don't waste time setting default again
 			
 			await nativeUpdateProfile(curProfile.id, curProfile.name, curProfile.avatar, true, curProfile.options);

--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -75,9 +75,9 @@ async function initNativePort(eventCallback) {
             curProfileId = profileListData.current_profile_id;
         }
     }
-	
-	browser.windows.onFocusChanged.addListener(onWindowFocusChange);
-	
+    
+    browser.windows.onFocusChanged.addListener(onWindowFocusChange);
+    
     nativeRequestInternal(nativePort, "Initialize", {
         extension_id: EXTENSION_ID,
         extension_version: APP_VERSION,
@@ -242,17 +242,17 @@ export async function nativeUpdateProfileOrder(order) {
 
 //Make the last focused window be the current "Default Profile" so that external links open in whatever was the last window you focused.
 export async function onWindowFocusChange(windowID) {
-	//We're not in the currently active Profile or no main window has been focused again yet
-	if(windowID < 0) { return; }
+    //We're not in the currently active Profile or no main window has been focused again yet
+    if(windowID < 0) { return; }
 
-	const profileList = await browser.storage.local.get(STORAGE_CACHE_PROFILE_LIST_KEY);
+    const profileList = await browser.storage.local.get(STORAGE_CACHE_PROFILE_LIST_KEY);
     if(profileList != null) {
         const profileListData = profileList[STORAGE_CACHE_PROFILE_LIST_KEY];
         if(profileListData != null) {
             const curProfile = profileListData.profiles.find((profile) => profile.id == profileListData.current_profile_id);
-			if(curProfile.default == true) { return; } //Don't waste time setting default again
-			
-			await nativeUpdateProfile(curProfile.id, curProfile.name, curProfile.avatar, true, curProfile.options);
+            if(curProfile.default == true) { return; } //Don't waste time setting default again
+            
+            await nativeUpdateProfile(curProfile.id, curProfile.name, curProfile.avatar, true, curProfile.options);
         }
     }
 }


### PR DESCRIPTION
Whenever window focus changes, the Default Profile will be set to whatever the new window is. This will then ensure external links you click will open in your last focused window instead of the pre-set Default Profile.

A lot of people coming from Chrome complain about this missing in Firefox, and Firefox used to have this behaviour. It's a lot better for usability.

I dunno if something extra needs to be done to add the function, I don't know anything about the Svelte stuff, I just tested with the extension unpacked.